### PR TITLE
Fix EZP-23217: Ruleset settings not taken into account

### DIFF
--- a/DependencyInjection/ConfigurationMapper.php
+++ b/DependencyInjection/ConfigurationMapper.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File containing the ConfigurationMap class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\CommentsBundle\DependencyInjection;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\HookableConfigurationMapperInterface;
+
+class ConfigurationMapper implements HookableConfigurationMapperInterface
+{
+    public function mapConfig( array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer )
+    {
+        // Common settings
+        if ( isset( $scopeSettings['default_provider'] ) )
+            $contextualizer->setContextualParameter( 'default_provider', $currentScope, $scopeSettings['default_provider'] );
+        if ( isset( $scopeSettings['content_comments'] ) )
+        {
+            $scopeSettings['content_comments'] = array( 'comments' => $scopeSettings['content_comments'] );
+        }
+
+        // Disqus
+        if ( isset( $scopeSettings['disqus']['shortname'] ) )
+            $contextualizer->setContextualParameter( 'disqus.shortname', $currentScope, $scopeSettings['disqus']['shortname'] );
+        if ( isset( $scopeSettings['disqus']['template'] ) )
+            $contextualizer->setContextualParameter( 'disqus.default_template', $currentScope, $scopeSettings['disqus']['template'] );
+
+        // Facebook
+        if ( isset( $scopeSettings['facebook']['app_id'] ) )
+            $contextualizer->setContextualParameter( 'facebook.app_id', $currentScope, $scopeSettings['facebook']['app_id'] );
+        if ( isset( $scopeSettings['facebook']['width'] ) )
+            $contextualizer->setContextualParameter( 'facebook.width', $currentScope, $scopeSettings['facebook']['width'] );
+        if ( isset( $scopeSettings['facebook']['num_posts'] ) )
+            $contextualizer->setContextualParameter( 'facebook.num_posts', $currentScope, $scopeSettings['facebook']['num_posts'] );
+        if ( isset( $scopeSettings['facebook']['color_scheme'] ) )
+            $contextualizer->setContextualParameter( 'facebook.color_scheme', $currentScope, $scopeSettings['facebook']['color_scheme'] );
+        if ( isset( $scopeSettings['facebook']['include_sdk'] ) )
+            $contextualizer->setContextualParameter( 'facebook.include_sdk', $currentScope, $scopeSettings['facebook']['include_sdk'] );
+        if ( isset( $scopeSettings['facebook']['template'] ) )
+            $contextualizer->setContextualParameter( 'facebook.default_template', $currentScope, $scopeSettings['facebook']['template'] );
+    }
+
+    public function preMap( array $config, ContextualizerInterface $contextualizer )
+    {
+        // Nothing to do here.
+    }
+
+    public function postMap( array $config, ContextualizerInterface $contextualizer )
+    {
+        $contextualizer->mapConfigArray( 'content_comments', $config, ContextualizerInterface::MERGE_FROM_SECOND_LEVEL );
+    }
+}

--- a/DependencyInjection/EzSystemsCommentsExtension.php
+++ b/DependencyInjection/EzSystemsCommentsExtension.php
@@ -16,11 +16,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
-/**
- * This is the class that loads and manages your bundle configuration
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
- */
 class EzSystemsCommentsExtension extends Extension
 {
     public function load( array $configs, ContainerBuilder $container )
@@ -33,36 +28,7 @@ class EzSystemsCommentsExtension extends Extension
         $loader->load( 'default_settings.yml' );
 
         $processor = new ConfigurationProcessor( $container, 'ez_comments' );
-        $processor->mapConfig(
-            $config,
-            function ( $scopeSettings, $currentScope, ContextualizerInterface $contextualizer )
-            {
-                // Common settings
-                if ( isset( $scopeSettings['default_provider'] ) )
-                    $contextualizer->setContextualParameter( 'default_provider', $currentScope, $scopeSettings['default_provider'] );
-
-                // Disqus
-                if ( isset( $scopeSettings['disqus']['shortname'] ) )
-                    $contextualizer->setContextualParameter( 'disqus.shortname', $currentScope, $scopeSettings['disqus']['shortname'] );
-                if ( isset( $scopeSettings['disqus']['template'] ) )
-                    $contextualizer->setContextualParameter( 'disqus.default_template', $currentScope, $scopeSettings['disqus']['template'] );
-
-                // Facebook
-                if ( isset( $scopeSettings['facebook']['app_id'] ) )
-                    $contextualizer->setContextualParameter( 'facebook.app_id', $currentScope, $scopeSettings['facebook']['app_id'] );
-                if ( isset( $scopeSettings['facebook']['width'] ) )
-                    $contextualizer->setContextualParameter( 'facebook.width', $currentScope, $scopeSettings['facebook']['width'] );
-                if ( isset( $scopeSettings['facebook']['num_posts'] ) )
-                    $contextualizer->setContextualParameter( 'facebook.num_posts', $currentScope, $scopeSettings['facebook']['num_posts'] );
-                if ( isset( $scopeSettings['facebook']['color_scheme'] ) )
-                    $contextualizer->setContextualParameter( 'facebook.color_scheme', $currentScope, $scopeSettings['facebook']['color_scheme'] );
-                if ( isset( $scopeSettings['facebook']['include_sdk'] ) )
-                    $contextualizer->setContextualParameter( 'facebook.include_sdk', $currentScope, $scopeSettings['facebook']['include_sdk'] );
-                if ( isset( $scopeSettings['facebook']['template'] ) )
-                    $contextualizer->setContextualParameter( 'facebook.default_template', $currentScope, $scopeSettings['facebook']['template'] );
-            }
-        );
-        $processor->mapConfigArray( 'content_comments', $config, ContextualizerInterface::MERGE_FROM_SECOND_LEVEL );
+        $processor->mapConfig( $config, new ConfigurationMapper() );
     }
 
     public function getAlias()

--- a/Tests/DependencyInjection/EzSystemsCommentsExtensionTest.php
+++ b/Tests/DependencyInjection/EzSystemsCommentsExtensionTest.php
@@ -97,7 +97,7 @@ class EzSystemsCommentsExtensionTest extends AbstractExtensionTestCase
     public function testContentComments()
     {
         $providerSa1 = 'disqus';
-        $contentCommentsSa1 = $expectedContentCommentsSa1 = array(
+        $contentCommentsSa1 = array(
             'public_articles' => array(
                 'enabled' => true,
                 'provider' => 'facebook',
@@ -117,6 +117,7 @@ class EzSystemsCommentsExtensionTest extends AbstractExtensionTestCase
                 'options' => array( 'width' => 470 )
             )
         );
+        $expectedContentCommentsSa1 = array( 'comments' => $contentCommentsSa1 );
 
         $providerSaGroup = 'facebook';
         $contentCommentsSaGroup = array(
@@ -137,22 +138,24 @@ class EzSystemsCommentsExtensionTest extends AbstractExtensionTestCase
             )
         );
         $expectedCommentsSaGroup = array(
-            'nights_watch_comments' => array(
-                'enabled' => false,
-                'provider' => 'raven',
-                'match' => array(
-                    'Identifier\\ContentType' => array( 'men_request', 'complaints' ),
+            'comments' => array(
+                'nights_watch_comments' => array(
+                    'enabled' => false,
+                    'provider' => 'raven',
+                    'match' => array(
+                        'Identifier\\ContentType' => array( 'men_request', 'complaints' ),
+                    ),
+                    'options' => array()
                 ),
-                'options' => array()
-            ),
-            'cersei_comments' => array(
-                'enabled' => true,
-                'provider' => 'i_dont_care',
-                'match' => array(
-                    'Identifier\\ContentType' => array( 'more_wine', 'more_blood' ),
-                    'Identifier\\Section' => 'private',
-                ),
-                'options' => array()
+                'cersei_comments' => array(
+                    'enabled' => true,
+                    'provider' => 'i_dont_care',
+                    'match' => array(
+                        'Identifier\\ContentType' => array( 'more_wine', 'more_blood' ),
+                        'Identifier\\Section' => 'private',
+                    ),
+                    'options' => array()
+                )
             )
         );
 
@@ -170,29 +173,36 @@ class EzSystemsCommentsExtensionTest extends AbstractExtensionTestCase
                 'enabled' => false
             ),
             'nights_watch_comments' => array(
-                'enabled' => true
+                'enabled' => true,
+                'provider' => 'raven',
+                'match' => array(
+                    'Identifier\\ContentType' => array( 'men_request', 'complaints' ),
+                )
             )
         );
         $expectedContentCommentsSa3 = array(
-            'nights_watch_comments' => array(
-                'enabled' => true,
-                'provider' => 'raven',
-                'match' => array(),
-                'options' => array()
-            ),
-            'cersei_comments' => array(
-                'enabled' => false,
-                'provider' => 'i_dont_care',
-                'match' => array(),
-                'options' => array()
-            ),
-            'melisandre_comments' => array(
-                'enabled' => true,
-                'provider' => 'stanis_baratheon',
-                'match' => array(
-                    'God\\Type' => 'fire_fire_FIRE'
+            'comments' => array(
+                'nights_watch_comments' => array(
+                    'enabled' => true,
+                    'provider' => 'raven',
+                    'match' => array(
+                        'Identifier\\ContentType' => array( 'men_request', 'complaints' ),
+                    ),
+                    'options' => array()
                 ),
-                'options' => array()
+                'cersei_comments' => array(
+                    'enabled' => false,
+                    'match' => array(),
+                    'options' => array()
+                ),
+                'melisandre_comments' => array(
+                    'enabled' => true,
+                    'provider' => 'stanis_baratheon',
+                    'match' => array(
+                        'God\\Type' => 'fire_fire_FIRE'
+                    ),
+                    'options' => array()
+                )
             )
         );
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23217
> Regression from [EZP-23163](https://jira.ez.no/browse/EZP-23163)

Regression was due to an omission of a key in internal config, during the configuration mapping process.

Tests have been updated.
