### PR TITLE
#23 Disqus add comment count

### DIFF
--- a/Comments/Provider/DisqusProvider.php
+++ b/Comments/Provider/DisqusProvider.php
@@ -22,9 +22,24 @@ class DisqusProvider extends TemplateBasedProvider
      */
     protected $shortName;
 
+    /**
+     * Enable count code.
+     *
+     * @var bool
+     */
+    protected $count = false;
+
     public function setShortName($shortName)
     {
         $this->shortName = $shortName;
+    }
+
+    /**
+     * @param bool $count
+     */
+    public function setCount($count)
+    {
+        $this->count = $count;
     }
 
     /**
@@ -42,6 +57,7 @@ class DisqusProvider extends TemplateBasedProvider
             $options + array(
                 'shortname' => $this->shortName,
                 'identifier' => $request->getPathInfo(),
+                'count' => $this->count,
             )
         );
     }
@@ -64,6 +80,7 @@ class DisqusProvider extends TemplateBasedProvider
                 'identifier' => $contentInfo->id,
                 // TODO: Use translated name
                 'title' => $contentInfo->name,
+                'count' => $this->count,
             )
         );
     }

--- a/Comments/Provider/SiteAccessAwareFactory.php
+++ b/Comments/Provider/SiteAccessAwareFactory.php
@@ -47,6 +47,7 @@ class SiteAccessAwareFactory
             $this->configResolver->getParameter('disqus.default_template', 'ez_comments')
         );
         $disqusProvider->setShortName($this->configResolver->getParameter('disqus.shortname', 'ez_comments'));
+        $disqusProvider->setCount($this->configResolver->getParameter('disqus.count', 'ez_comments'));
 
         return $disqusProvider;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,6 +90,7 @@ class Configuration extends SiteAccessConfiguration
                 ->children()
                     ->scalarNode('shortname')->isRequired()->info('Disqus "shortname"')->end()
                     ->scalarNode('template')->info('Template to use, overriding the built-in one.')->end()
+                    ->booleanNode('count')->defaultFalse()->info('Indicates if count code should be loaded or not')->end()
                 ->end()
             ->end();
     }

--- a/DependencyInjection/ConfigurationMapper.php
+++ b/DependencyInjection/ConfigurationMapper.php
@@ -32,6 +32,9 @@ class ConfigurationMapper implements HookableConfigurationMapperInterface
         if (isset($scopeSettings['disqus']['template'])) {
             $contextualizer->setContextualParameter('disqus.default_template', $currentScope, $scopeSettings['disqus']['template']);
         }
+        if (isset($scopeSettings['disqus']['count'])) {
+            $contextualizer->setContextualParameter('disqus.count', $currentScope, $scopeSettings['disqus']['count']);
+        }
 
         // Facebook
         if (isset($scopeSettings['facebook']['app_id'])) {

--- a/Resources/doc/02-configuration.md
+++ b/Resources/doc/02-configuration.md
@@ -74,7 +74,10 @@ ez_comments:
                 # Template to use, overriding the built-in one.
                 # Default template is "EzSystemsCommentsBundle::disqus.html.twig"
                 template:             ~
-```
+                
+                # Load JS code to render comment count
+                count: true|false
+```    
 
 #### Available options
 * `shortname`
@@ -83,6 +86,14 @@ ez_comments:
 * `url` (must be absolute, defaults to `window.location`)
 * `categoryId`
 * `template`
+
+#### Add comment count
+
+This bundle supports additional Disqus comments counter which is loaded in separate JavaScript file. 
+This counter is disabled by default and if you want to enable it, you have to follow these steps :
+
+- activate the count configuration
+- add an element with "disqus-comment-count" class as it is detailled in the [disqus documentation](https://help.disqus.com/customer/portal/articles/565624-adding-comment-count-links-to-your-home-page).
 
 ### Facebook
 Facebook provider is an integration of [Facebook Comments](https://developers.facebook.com/docs/reference/plugins/comments/)

--- a/Resources/views/disqus.html.twig
+++ b/Resources/views/disqus.html.twig
@@ -9,12 +9,19 @@
         {% if categoryId is defined %}var disqus_category_id = '{{ categoryId }}';{% endif %}
 
 
-        /* * * DON'T EDIT BELOW THIS LINE * * */
+        {# /* * * DON'T EDIT BELOW THIS LINE * * */ #}
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
             dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
+        {% if (count) %}
+        (function() {
+            var dsq_count = document.createElement('script'); dsq_count.type = 'text/javascript'; dsq_count.async = true;
+            dsq_count.src = '//' + disqus_shortname + '.disqus.com/count.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq_count);
+        })();
+        {% endif %}
     </script>
     <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
     <a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/Tests/Provider/DisqusTest.php
+++ b/Tests/Provider/DisqusTest.php
@@ -59,6 +59,7 @@ class DisqusTest extends TemplateBasedProviderTest
         return array(
             'shortname' => static::SHORTNAME,
             'identifier' => $request->getPathInfo(),
+            'count' => false,
         );
     }
 
@@ -77,6 +78,7 @@ class DisqusTest extends TemplateBasedProviderTest
             'shortname' => static::SHORTNAME,
             'identifier' => $contentInfo->id,
             'title' => $contentInfo->name,
+            'count' => false,
         );
     }
 }


### PR DESCRIPTION

## Description

This PR adds an new configuration 'count' for disqus provider, which allow to load js comment counter code.

## Test 

Manually on Ez demo post view page

Link to https://jira.ez.no/browse/DEMO-35