### PR TITLE
[5.4] EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,27 +1,36 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
-    ->setUsingLinter(false)
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        'concat_with_spaces',
-        '-concat_without_spaces',
-        '-empty_return',
-        '-phpdoc_params',
-        '-phpdoc_separation',
-        '-phpdoc_to_comment',
-        '-spaces_cast',
-        '-blankline_after_open_tag',
-        '-single_blank_line_before_namespace',
-    ])
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
-            ->in(__DIR__)
-            ->exclude([
-                'ezpublish_legacy',
-                'vendor',
-            ])
-            ->files()->name('*.php')
+// PHP-CS-Fixer 2.x syntax
+return PhpCsFixer\Config::create()
+    ->setRules(
+        [
+            '@Symfony' => true,
+            '@Symfony:risky' => true,
+            'concat_space' => ['spacing' => 'one'],
+            'array_syntax' => false,
+            'simplified_null_return' => false,
+            'phpdoc_align' => false,
+            'phpdoc_separation' => false,
+            'phpdoc_to_comment' => false,
+            'cast_spaces' => false,
+            'blank_line_after_opening_tag' => false,
+            'single_blank_line_before_namespace' => false,
+            'phpdoc_annotation_without_dot' => false,
+            'phpdoc_no_alias_tag' => false,
+            'space_after_semicolon' => false,
+            'yoda_style' => false,
+            'no_break_comment' => false,
+        ]
     )
-;
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude(
+                [
+                    'ezpublish_legacy',
+                    'vendor',
+                ]
+            )
+            ->files()->name('*.php')
+    );

--- a/Tests/CommentsRendererTest.php
+++ b/Tests/CommentsRendererTest.php
@@ -94,7 +94,7 @@ class CommentsRendererTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testGetInvalidProvider()
     {


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161) for 5.4

This PR backports to `5.4` updated `.php_cs` config and aligns CS

**TODO**:
- [x] Check if ezrobot runs 2.7.1 on this repo (AFAIK should, but `.php_cs` was still in 1.x format)
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Update CS (applied `php_unit_fqcn_annotation` CS rule) #