### PR TITLE
EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,27 +1,36 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
-    ->setUsingLinter(false)
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        'concat_with_spaces',
-        '-concat_without_spaces',
-        '-empty_return',
-        '-phpdoc_params',
-        '-phpdoc_separation',
-        '-phpdoc_to_comment',
-        '-spaces_cast',
-        '-blankline_after_open_tag',
-        '-single_blank_line_before_namespace',
-    ])
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
-            ->in(__DIR__)
-            ->exclude([
-                'ezpublish_legacy',
-                'vendor',
-            ])
-            ->files()->name('*.php')
+// PHP-CS-Fixer 2.x syntax
+return PhpCsFixer\Config::create()
+    ->setRules(
+        [
+            '@Symfony' => true,
+            '@Symfony:risky' => true,
+            'concat_space' => ['spacing' => 'one'],
+            'array_syntax' => false,
+            'simplified_null_return' => false,
+            'phpdoc_align' => false,
+            'phpdoc_separation' => false,
+            'phpdoc_to_comment' => false,
+            'cast_spaces' => false,
+            'blank_line_after_opening_tag' => false,
+            'single_blank_line_before_namespace' => false,
+            'phpdoc_annotation_without_dot' => false,
+            'phpdoc_no_alias_tag' => false,
+            'space_after_semicolon' => false,
+            'yoda_style' => false,
+            'no_break_comment' => false,
+        ]
     )
-;
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude(
+                [
+                    'ezpublish_legacy',
+                    'vendor',
+                ]
+            )
+            ->files()->name('*.php')
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
     - 5.6
     - 7.0
+    - 7.1
 
 # test only master (+ Pull requests)
 branches:

--- a/Tests/CommentsRendererTest.php
+++ b/Tests/CommentsRendererTest.php
@@ -99,7 +99,7 @@ class CommentsRendererTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testGetInvalidProvider()
     {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",
+        "friendsofphp/php-cs-fixer": "~2.7.1",
         "matthiasnoback/symfony-dependency-injection-test": "0.*"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "psr-0": {"EzSystems\\CommentsBundle": ""}
     },
     "target-dir": "EzSystems/CommentsBundle",
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "6.1.x-dev"


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161) for 6.x

This PR updates `.php_cs` config and aligns CS.
To simplify fixing code it adds dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] ~~Check if it is possible to merge-up #27~~ _Not applicable, 5.x branches does not follow git flow_
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Update CS (applied `php_unit_fqcn_annotation` CS rule)
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`