### PR TITLE
PHPUnit 5 and 6 support

### DIFF
--- a/Tests/Provider/FacebookTest.php
+++ b/Tests/Provider/FacebookTest.php
@@ -10,9 +10,12 @@
  */
 namespace EzSystems\CommentsBundle\Tests\Provider;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\CommentsBundle\Comments\Provider\FacebookProvider;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
 
 class FacebookTest extends TemplateBasedProviderTest
@@ -59,7 +62,7 @@ class FacebookTest extends TemplateBasedProviderTest
     private function getLocationService()
     {
         if (!isset($this->locationService)) {
-            $this->locationService = $this->getMock('eZ\\Publish\\API\\Repository\\LocationService');
+            $this->locationService = $this->createMock(LocationService::class);
         }
 
         return $this->locationService;
@@ -71,7 +74,9 @@ class FacebookTest extends TemplateBasedProviderTest
     private function getRouter()
     {
         if (!isset($this->router)) {
-            $this->router = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+            $this->router = $this->getMockBuilder(RouterInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock();
         }
 
         return $this->router;
@@ -155,7 +160,7 @@ class FacebookTest extends TemplateBasedProviderTest
 
     private function getContentUrl(ContentInfo $contentInfo)
     {
-        $mainLocation = $this->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\Content\\Location')
+        $mainLocation = $this->getMockBuilder(Location::class)
             ->setConstructorArgs(array(array('id' => $contentInfo->mainLocationId)))
             ->getMock();
 

--- a/Tests/Provider/TemplateBasedProviderTest.php
+++ b/Tests/Provider/TemplateBasedProviderTest.php
@@ -12,11 +12,11 @@ namespace EzSystems\CommentsBundle\Tests\Provider;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Templating\EngineInterface;
 
-abstract class TemplateBasedProviderTest extends PHPUnit_Framework_TestCase
+abstract class TemplateBasedProviderTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Templating\EngineInterface
@@ -26,7 +26,7 @@ abstract class TemplateBasedProviderTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->templateEngine = $this->getMock('Symfony\\Component\\Templating\\EngineInterface');
+        $this->templateEngine = $this->createMock(EngineInterface::class);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "symfony-cmf/routing": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7",
+        "phpunit/phpunit": "^5.7|^6.0",
         "friendsofphp/php-cs-fixer": "~2.7.1",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*"
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0|~2.0"
     },
     "suggest": {
         "ezsystems/ngsymfonytools-bundle": "Needed for use with legacy backend tab for administration of comments"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    colors="false">
+    colors="true">
     <testsuites>
         <testsuite name="CommentsBundle test suite">
             <directory>./Tests</directory>


### PR DESCRIPTION
This PR resolves:
* enables install of PHPUnit v5 and v6
* test cases now extend from namespaced test case
* uses class constants in tests
* enables symfony-dependency-injection-test `~1.0` or `~2.0`