### PR TITLE
Delete symfony-cmf/routing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.0@dev || ^7.0@dev",
-        "symfony-cmf/routing": "~1.1"
+        "ezsystems/ezpublish-kernel": "~6.0@dev || ^7.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",


### PR DESCRIPTION
symfony-cmf/routing dependency is not necessary as it is included on ezsystems/ezpublish-kernel